### PR TITLE
Change more details to slides & videos

### DIFF
--- a/app/views/sessions/managesessions.scala.html
+++ b/app/views/sessions/managesessions.scala.html
@@ -39,7 +39,7 @@
                                 <th>Cancelled</th>
                                 <th>Rating</th>
                                 <th>Scheduled Status</th>
-                                <th>More Details</th>
+                                <th>Slides & Videos</th>
                             </tr>
                         </thead>
                         <tbody id="user-found">
@@ -98,7 +98,7 @@
                                 }
                                 </td>
                                 @if(knolxSession.completed && !knolxSession.cancelled) {
-                                <td title="Click here for more details" class='clickable-row'>
+                                <td title="Click here for slides & videos" class='clickable-row'>
                                     <a href='@routes.SessionsController.shareContent(knolxSession.id)'
                                        style="text-decoration: none;"><span class="label more-detail-session">Click here</span></a>
                                     } else if(knolxSession.cancelled) {

--- a/app/views/sessions/sessions.scala.html
+++ b/app/views/sessions/sessions.scala.html
@@ -36,7 +36,7 @@
                                 <th>Type</th>
                                 <th>Cancelled</th>
                                 <th>Status</th>
-                                <th>More Details</th>
+                                <th>Slides & Videos</th>
                             </tr>
                         </thead>
                         <tbody id="user-found">
@@ -68,7 +68,7 @@
                                 </td>
 
                                 @if(knolxSession.completed && !knolxSession.cancelled) {
-                                <td title="Click here for more details" class='clickable-row'>
+                                <td title="Click here for slides & videos" class='clickable-row'>
                                     <a href='@routes.SessionsController.shareContent(knolxSession.id)'
                                        style="text-decoration: none;"><span class="label more-detail-session">Click here</span></a>
                                 } else if(knolxSession.cancelled) {

--- a/public/javascripts/searchmanagesession.js
+++ b/public/javascripts/searchmanagesession.js
@@ -80,7 +80,7 @@ function slide(keyword, pageNumber) {
                         }
 
                         if (sessions[session].completed && !sessions[session].cancelled) {
-                            usersFound += "<td  title='Click here for more details' class='clickable-row'>" +
+                            usersFound += "<td  title='Click here for slides & videos' class='clickable-row'>" +
                                           "<a href='" + jsRoutes.controllers.SessionsController.shareContent(sessions[session].id)['url'] +
                                           "' style='text-decoration: none;'><span class='label more-detail-session'>Click here</span></a>";
                         } else if(sessions[session].cancelled) {

--- a/public/javascripts/searchsession.js
+++ b/public/javascripts/searchsession.js
@@ -57,7 +57,7 @@ function slide(keyword, pageNumber) {
                         }
 
                         if (sessions[session].completed && !sessions[session].cancelled) {
-                           usersFound += "<td  title='Click here for more details' class='clickable-row'>" +
+                           usersFound += "<td  title='Click here for slides & videos' class='clickable-row'>" +
                             "<a href='" + jsRoutes.controllers.SessionsController.shareContent(sessions[session].id)['url'] +
                             "' style='text-decoration: none;'><span class='label more-detail-session'>Click here</span></a>";
                         } else if(sessions[session].cancelled) {


### PR DESCRIPTION
Resolve issue #196 :
Rename "More Details" to "Slides & Videos" on Home and Manage Sessions page.